### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Solrstrap
+# Solrstrap
 
 [Solrstrap](http://fergiemcdowall.github.com/solrstrap/) is a Query-Result interface for Solr. [Solrstrap](http://fergiemcdowall.github.com/solrstrap/) is intended to be a starting point for those building web interfaces that talk to Solr, or a very lightweight admin tool for querying Solr in a Googleish fashion.
 
@@ -8,7 +8,7 @@
 
 **CLONE, FORK, GAZE AT CODE:** https://github.com/fergiemcdowall/solrstrap/
 
-#What does Solrstrap do?
+# What does Solrstrap do?
 Solrstrap takes search queries and displays search results. It also features:
 * Instant search
 * Infinite scrolling
@@ -16,39 +16,39 @@ Solrstrap takes search queries and displays search results. It also features:
 * Restful interface (you can link directly to /solrstrap.html?q=doughnuts)
 * Functioning history
 
-#Solrstrap is probably the fastest available rendering engine for Solr.
+# Solrstrap is probably the fastest available rendering engine for Solr.
 
 This is because it does everything in Javascript, CSS and HTML on the client side. JSON is shot back from the server and interpeted by the web browser.
 
 Solrstrap therefore requires much less server power and bandwidth than standard search-middleware applications.
 
-#Installation, How do I make it work?
+# Installation, How do I make it work?
 Optionally edit SERVERROOT in /js/solrstrap.js to point to the "select" endpoint of your solr instance, and HITTITLE/HITBODY to reference the appropriate fields in your index
 
 Click on /solrstrap.html.
 
 Thats it.
 
-#What is Solrstrap made of?
+# What is Solrstrap made of?
 Solrstrap is lovingly crafted from [Bootstrap](http://twitter.github.com/bootstrap/) and [Handlebars](http://handlebarsjs.com).
 
-#Strengths
+# Strengths
 * Requires _only_ local installation- very easy to set up
 * Access to all Bootstrap functionality. Can be easily extended in a Bootstrappy way.
 * Blazing fast
 * Uses very little bandwidth
 
-#Weaknesses
+# Weaknesses
 * Designed for "open" solr instances- needs clear access to /select/q=.
 * SEO basically non-existant
 * Will (probably) not work on truly ancient browsers (IE 7 and below)
 
-#Future releases
+# Future releases
 * Some form of arrow key functionality...
 * Meaningful error messages and sanity checks...
 * Nicer code
 
-#License
+# License
 Copyright 2013 Fergus McDowall
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,7 +63,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-#Contact
+# Contact
 Follow/contact me on Twitter [@fergiemcdowall](https://twitter.com/fergiemcdowall)
 
 I write articles about search engine technology here: http://blog.comperiosearch.com/blog/author/fmcdowall/


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
